### PR TITLE
Fix defaults with boolean types

### DIFF
--- a/lib/mini_defender/validates_input.rb
+++ b/lib/mini_defender/validates_input.rb
@@ -7,7 +7,7 @@ module MiniDefender::ValidatesInput
     data = cleanse_data(params.to_unsafe_hash.deep_stringify_keys)
     validator = MiniDefender::Validator.new(rules, data)
     validator.validate!
-    coerced ? validator.coerced : validator.data
+    coerced ? validator.coerced : validator.validated
   end
 
   private

--- a/lib/mini_defender/validator.rb
+++ b/lib/mini_defender/validator.rb
@@ -28,7 +28,7 @@ module MiniDefender
 
       # Set default values for missing data key compared to rules
       data_rules.each do |k, set|
-        if !@data.key?(k) || @data[k].blank?
+        if !@data.key?(k) || missing_value?(@data[k])
           set.filter{ |r| r.defaults?(self) }.each do |r|
             @data.merge!({k => r.default_value(self)}.flatten_keys(keep_roots: true))
           end
@@ -43,7 +43,7 @@ module MiniDefender
         value_included = true
         required = rule_set.any? { |r| r.implicit?(self) }
 
-        if !@data.key?(k) || @data[k].blank?
+        if !@data.key?(k) || missing_value?(@data[k])
           rule_set.filter{ |r| r.defaults?(self) }.each do |r|
             @data.merge!({k => r.default_value(self)}.flatten_keys(keep_roots: true))
           end
@@ -187,6 +187,13 @@ module MiniDefender
       end
 
       result
+    end
+
+    def missing_value?(value)
+      value.nil? ||
+        value.is_a?(String) && value.strip.empty? ||
+        value.is_a?(Hash) && value.empty? ||
+        value.is_a?(Array) && value.empty?
     end
   end
 end

--- a/lib/mini_defender/version.rb
+++ b/lib/mini_defender/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MiniDefender
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -115,4 +115,27 @@ class ValidatorTest < Minitest::Test
       }
     )
   end
+
+  def test_only_validated_data_should_be_returned
+    v = MiniDefender::Validator.new(
+      {
+        'address' => 'required|hash',
+        'address.is_personal' => 'required|boolean|default:true',
+      },
+      {
+        'address' => {
+          'is_personal' => false
+        },
+        'name' => 'John Doe'
+      }
+    )
+
+    v.validate!
+    data = v.validated
+
+    assert_equal 1, data.length
+    assert data['address'].is_a?(Hash)
+    assert data['address'].key?('is_personal')
+    assert data['address']['is_personal'].is_a?(FalseClass)
+  end
 end


### PR DESCRIPTION
Code used to consider false as missing, while it should be considered given. This commit also patches `ValidatesInput` concern to return only validated