### PR TITLE
Fix date_eq Rule to Accept a Single Argument

### DIFF
--- a/lib/mini_defender/rules/date_eq.rb
+++ b/lib/mini_defender/rules/date_eq.rb
@@ -13,7 +13,7 @@ class MiniDefender::Rules::DateEq < MiniDefender::Rule
   end
 
   def self.make(args)
-    raise ArgumentError, 'Target date is required for date rules.' unless args == 1
+    raise ArgumentError, 'Target date is required for date rules.' unless args.length == 1
 
     self.new(args[0])
   end


### PR DESCRIPTION
Hello @ahoshaiyan 👋

Currently, given the following rule:

```rb
{
  'consented_at' => "required|string|date|date_lte:#{Time.now.iso8601}",
}
```

The following request will result in an exception `#<ArgumentError: Target date is required for date rules.`

```json
{
  "consented_at": "2024-08-13T16:54:35-04:00"
}
```

This PR should be the fix. Please let me know if you have any comments. 🙏